### PR TITLE
Add correction for Listing 4-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Enjoy!
 ***
 
 ## Errata
-* Corrections go here.
+Listing 4-14 : `grep -Hnio "graphiql\|graphql-playground" dvga-report/source/*`
 


### PR DESCRIPTION
The `grep` command in Listing 4-14 on page 83 is missing a backslash before the pipe.

It should be `grep -Hnio "graphiql\|graphql-playground" dvga-report/source/*` instead of `grep -Hnio "graphiql|graphql-playground" dvga-report/source/*`.

I added the correction in its simplest form to the `README`, let me know if you would like me to add more information or if there is a format that should be followed.